### PR TITLE
Ensure `curl` and `zlib1g-dev` are installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
       make \
       build-essential \
       libssl-dev \
+      curl \
   && rm -rf /var/lib/apt/lists/*
 
 ENV CHECKLINK_VERSION 4_81

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ RUN apt-get update && apt-get install -y \
       build-essential \
       libssl-dev \
       curl \
+      zlib1g-dev \
   && rm -rf /var/lib/apt/lists/*
 
 ENV CHECKLINK_VERSION 4_81


### PR DESCRIPTION
Fixes error:
```shell
=> ERROR [3/3] RUN set -x   && curl -sSL https://github.com/w3c/link-checker/archive/checklink-4_81.tar.gz -o /tmp/link-checker.tar.gz   && mkdir -p /usr/src   && tar -xzf /tmp/link-checker.tar.gz -C /usr/src   && rm /tmp/link-checker.tar.gz     0.4s
------
 > [3/3] RUN set -x   && curl -sSL https://github.com/w3c/link-checker/archive/checklink-4_81.tar.gz -o /tmp/link-checker.tar.gz   && mkdir -p /usr/src   && tar -xzf /tmp/link-checker.tar.gz -C /usr/src   && rm /tmp/link-checker.tar.gz   && cd /usr/src/link-checker-checklink-4_81   && cpanm --installdeps .   && cpanm LWP::Protocol::https   && perl Makefile.PL   && make   && make test   && make install   && rm -rf /usr/src/link-checker-checklink-4_81:
0.357 + curl -sSL https://github.com/w3c/link-checker/archive/checklink-4_81.tar.gz -o /tmp/link-checker.tar.gz
0.357 /bin/sh: 1: curl: not found
------
Dockerfile:17
```

After this change, the error below occurs later in the build of the Docker image:
```shell
3.029 + cpanm --installdeps .
...
156.6 Configuring Net-SSLeay-1.92 ... OK
156.8 Building and testing Net-SSLeay-1.92 ... ! Installing Net::SSLeay failed. See /root/.cpanm/work/1689091235.3196/build.log for details. Retry with --force to force install it.
169.2 ! Installing the dependencies failed: Module 'Net::SSLeay' is not installed
169.2 ! Bailing out the installation for IO-Socket-SSL-2.083.
169.2 ! Installing the dependencies failed: Module 'IO::Socket::SSL::Utils' is not installed, Module 'IO::Socket::SSL' is not installed
169.2 ! Bailing out the installation for LWP-Protocol-https-6.11.
169.2 FAIL
```

To fix this, I then installed `zlib1g-dev`.

Result: Joy!

Thanks for this Dockerfile!