### PR TITLE
fix: add `curl` dependency

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-get update && apt-get install -y \
       make \
       build-essential \
       libssl-dev \
+      curl \
   && rm -rf /var/lib/apt/lists/*
 
 ENV CHECKLINK_VERSION 4_81


### PR DESCRIPTION
The `RUN` directive that downloads the link checker distribution uses `curl` to do so but the `apt-get` commands that run earlier don't actually install `curl`. This fixes that to avoid this error:

```
 => ERROR [3/3] RUN set -x   && curl -sSL https://github.com/w3c/link-checker/archive/checklink-4_81.tar.gz -o /tmp/link-checker.tar.gz   && mkdir -p /usr/src   && tar -xzf /tm  0.1s
------
 > [3/3] RUN set -x   && curl -sSL https://github.com/w3c/link-checker/archive/checklink-4_81.tar.gz -o /tmp/link-checker.tar.gz   && mkdir -p /usr/src   && tar -xzf /tmp/link-checker.tar.gz -C /usr/src   && rm /tmp/link-checker.tar.gz   && cd /usr/src/link-checker-checklink-4_81   && cpanm --installdeps .   && cpanm LWP::Protocol::https   && perl Makefile.PL   && make   && make test   && make install   && rm -rf /usr/src/link-checker-checklink-4_81:
0.105 + curl -sSL https://github.com/w3c/link-checker/archive/checklink-4_81.tar.gz -o /tmp/link-checker.tar.gz
0.105 /bin/sh: 1: curl: not found
```